### PR TITLE
Fix handling of GitHub Actions CI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,7 @@
 [run]
 branch = True
 source = websocket-client
-omit = websocket/tests/*
+omit = websocket/tests/*,websocket/_wsdump.py
 
 [report]
 exclude_lines =

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -24,7 +24,7 @@ jobs:
           pytest -vrP --cov=websocket websocket/tests --cov-config=.coveragerc
           coverage report
       - name: Confirm that wsdump script works and doesn't result in an error
-        run: /opt/hostedtoolcache/Python/3.10.0/x64/bin/wsdump -h
+        run: wsdump.py -h
       - name: Install wsaccel and python-socks, then run all test cases for coverage collection
         run: |
           pip3 install wsaccel python-socks

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -24,7 +24,7 @@ jobs:
           pytest -vrP --cov=websocket websocket/tests --cov-config=.coveragerc
           coverage report
       - name: Confirm that wsdump script works and doesn't result in an error
-        run: wsdump -h
+        run: /opt/hostedtoolcache/Python/3.10.0/x64/bin/wsdump -h
       - name: Install wsaccel and python-socks, then run all test cases for coverage collection
         run: |
           pip3 install wsaccel python-socks

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -23,6 +23,8 @@ jobs:
           python3 setup.py install
           pytest -vrP --cov=websocket websocket/tests --cov-config=.coveragerc
           coverage report
+      - name: Confirm that wsdump script works and doesn't result in an error
+        run: wsdump -h
       - name: Install wsaccel and python-socks, then run all test cases for coverage collection
         run: |
           pip3 install wsaccel python-socks


### PR DESCRIPTION
I sent a PR to suggest two changes to fix the handling of GitHub Actions CI:
1. Test the wsdump.py script with `wsdump.py -h` (I tried `wsdump -h` but CI required the .py extension) right after websocket-client is installed. websocket-client currently doesn't get installed in the build.yml test, so I put this check in codecoverage.yml
2. Omit the wsdump.py script from code coverage because wsdump.py doesn't contribute any new functionality to the underlying websocket-client library. As long as the `wsdump.py -h` command doesn't trigger an error, the script should be installed. I'm not too concerned about code coverage for wsdump.py because most users of websocket-client are importing the library for custom purposes.